### PR TITLE
Restore compatibility with 4.01.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*.cm?
+*.a
+*.o
+*.cmxa
+/Makefile
+/autom4te.cache/
+/config.log
+/config.status
+/src/Makefile.common
+/src/ollvm/ollvm_lexer.ml
+/src/ollvm/ollvm_parser.ml
+/src/ollvm/ollvm_parser.mli

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,3 +35,6 @@ doc:
 	make -C src/ollvm doc
 
 endif
+
+README: README.md
+	cp -f README.md README

--- a/Makefile.in
+++ b/Makefile.in
@@ -590,6 +590,9 @@ uninstall-am:
 @BUILD_LLVMGATEWAY_FALSE@doc:
 @BUILD_LLVMGATEWAY_FALSE@	make -C src/ollvm doc
 
+README: README.md
+	cp -f README.md README
+
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.
 .NOEXPORT:

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -573,7 +573,8 @@ to "yes", and re-run configure.
 END
     AC_MSG_ERROR([Your 'rm' program is bad, sorry.])
   fi
-fi])
+fi
+])
 
 dnl Hook into '_AC_COMPILER_EXEEXT' early to learn its expansion.  Do not
 dnl add the conditional right here, as _AC_COMPILER_EXEEXT may be further

--- a/configure
+++ b/configure
@@ -2417,6 +2417,7 @@ END
   fi
 fi
 
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
 $as_echo_n "checking whether to enable maintainer-specific portions of Makefiles... " >&6; }
     # Check whether --enable-maintainer-mode was given.
@@ -4510,8 +4511,28 @@ fi
 
 MAJOR=`echo "$OCAMLVERSION" | cut -d. -f1`
 MINOR=`echo "$OCAMLVERSION" | cut -d. -f2`
+if test "$MAJOR" -lt 4 || (test "$MAJOR" -eq 4 && test "$MINOR" -lt 01) ; then
+  as_fn_error $? "ocaml 4.01 or higher is required." "$LINENO" 5
+fi
+
 if test "$MAJOR" -lt 4 || (test "$MAJOR" -eq 4 && test "$MINOR" -lt 02) ; then
-  as_fn_error $? "ocaml 4.02 or higher is required." "$LINENO" 5
+
+cat <<EOF > src/ollvm/ollvm.mli
+module Ast : module type of Ollvm_ast
+module Lexer : module type of Ollvm_lexer
+module Printer : module type of Ollvm_printer
+module Ez : module type of Ollvm_ez
+EOF
+
+else
+
+cat <<EOF > src/ollvm/ollvm.mli
+module Ast = Ollvm_ast
+module Lexer = Ollvm_lexer
+module Printer = Ollvm_printer
+module Ez = Ollvm_ez
+EOF
+
 fi
 
 # ocamlfind

--- a/configure.ac
+++ b/configure.ac
@@ -23,8 +23,28 @@ fi
 
 MAJOR=`echo "$OCAMLVERSION" | cut -d. -f1`
 MINOR=`echo "$OCAMLVERSION" | cut -d. -f2`
+if test "$MAJOR" -lt 4 || (test "$MAJOR" -eq 4 && test "$MINOR" -lt 01) ; then
+  AC_MSG_ERROR([ocaml 4.01 or higher is required.])
+fi
+
 if test "$MAJOR" -lt 4 || (test "$MAJOR" -eq 4 && test "$MINOR" -lt 02) ; then
-  AC_MSG_ERROR([ocaml 4.02 or higher is required.])
+
+cat <<EOF > src/ollvm/ollvm.mli
+module Ast : module type of Ollvm_ast
+module Lexer : module type of Ollvm_lexer
+module Printer : module type of Ollvm_printer
+module Ez : module type of Ollvm_ez
+EOF
+
+else 
+
+cat <<EOF > src/ollvm/ollvm.mli
+module Ast = Ollvm_ast
+module Lexer = Ollvm_lexer
+module Printer = Ollvm_printer
+module Ez = Ollvm_ez
+EOF
+
 fi
 
 # ocamlfind

--- a/src/ollvm/.depend
+++ b/src/ollvm/.depend
@@ -1,9 +1,20 @@
-ollvm_ez.cmi : ollvm_ast.cmo
-ollvm_ast.cmo :
-ollvm_ast.cmx :
-ollvm_ez.cmo : ollvm_ast.cmo ollvm_ez.cmi
+ollvm.cmi : ollvm_printer.cmi ollvm_lexer.cmi ollvm_ez.cmi ollvm_ast.cmi
+ollvm_ast.cmi :
+ollvm_ez.cmi : ollvm_ast.cmi
+ollvm_lexer.cmi : ollvm_ast.cmi
+ollvm_parser.cmi : ollvm_ast.cmi
+ollvm_printer.cmi : ollvm_ast.cmi
+ollvm.cmo : ollvm_printer.cmi ollvm_lexer.cmi ollvm_ez.cmi ollvm_ast.cmi \
+    ollvm.cmi
+ollvm.cmx : ollvm_printer.cmx ollvm_lexer.cmx ollvm_ez.cmx ollvm_ast.cmx \
+    ollvm.cmi
+ollvm_ast.cmo : ollvm_ast.cmi
+ollvm_ast.cmx : ollvm_ast.cmi
+ollvm_ez.cmo : ollvm_ast.cmi ollvm_ez.cmi
 ollvm_ez.cmx : ollvm_ast.cmx ollvm_ez.cmi
-ollvm.cmo : ollvm_printer.cmo ollvm_ez.cmi ollvm_ast.cmo
-ollvm.cmx : ollvm_printer.cmx ollvm_ez.cmx ollvm_ast.cmx
-ollvm_printer.cmo : ollvm_ast.cmo
-ollvm_printer.cmx : ollvm_ast.cmx
+ollvm_lexer.cmo : ollvm_parser.cmi ollvm_lexer.cmi
+ollvm_lexer.cmx : ollvm_parser.cmx ollvm_lexer.cmi
+ollvm_parser.cmo : ollvm_ast.cmi ollvm_parser.cmi
+ollvm_parser.cmx : ollvm_ast.cmx ollvm_parser.cmi
+ollvm_printer.cmo : ollvm_ast.cmi ollvm_printer.cmi
+ollvm_printer.cmx : ollvm_ast.cmx ollvm_printer.cmi

--- a/src/ollvm/ollvm.mli
+++ b/src/ollvm/ollvm.mli
@@ -1,4 +1,0 @@
-module Ast = Ollvm_ast
-module Lexer = Ollvm_lexer
-module Printer = Ollvm_printer
-module Ez = Ollvm_ez

--- a/src/ollvm/ollvm_ast.mli
+++ b/src/ollvm/ollvm_ast.mli
@@ -1,0 +1,238 @@
+type linkage =
+    LINKAGE_Private
+  | LINKAGE_Internal
+  | LINKAGE_Available_externally
+  | LINKAGE_Linkonce
+  | LINKAGE_Weak
+  | LINKAGE_Common
+  | LINKAGE_Appending
+  | LINKAGE_Extern_weak
+  | LINKAGE_Linkonce_odr
+  | LINKAGE_Weak_odr
+  | LINKAGE_External
+and dll_storage = DLLSTORAGE_Dllimport | DLLSTORAGE_Dllexport
+and visibility =
+    VISIBILITY_Default
+  | VISIBILITY_Hidden
+  | VISIBILITY_Protected
+and cconv = CC_Ccc | CC_Fastcc | CC_Coldcc | CC_Cc of int
+and param_attr =
+    PARAMATTR_Zeroext
+  | PARAMATTR_Signext
+  | PARAMATTR_Inreg
+  | PARAMATTR_Byval
+  | PARAMATTR_Inalloca
+  | PARAMATTR_Sret
+  | PARAMATTR_Align of int
+  | PARAMATTR_Noalias
+  | PARAMATTR_Nocapture
+  | PARAMATTR_Nest
+  | PARAMATTR_Returned
+  | PARAMATTR_Nonnull
+  | PARAMATTR_Dereferenceable of int
+and fn_attr =
+    FNATTR_Alignstack of int
+  | FNATTR_Alwaysinline
+  | FNATTR_Builtin
+  | FNATTR_Cold
+  | FNATTR_Inlinehint
+  | FNATTR_Jumptable
+  | FNATTR_Minsize
+  | FNATTR_Naked
+  | FNATTR_Nobuiltin
+  | FNATTR_Noduplicate
+  | FNATTR_Noimplicitfloat
+  | FNATTR_Noinline
+  | FNATTR_Nonlazybind
+  | FNATTR_Noredzone
+  | FNATTR_Noreturn
+  | FNATTR_Nounwind
+  | FNATTR_Optnone
+  | FNATTR_Optsize
+  | FNATTR_Readnone
+  | FNATTR_Readonly
+  | FNATTR_Returns_twice
+  | FNATTR_Sanitize_address
+  | FNATTR_Sanitize_memory
+  | FNATTR_Sanitize_thread
+  | FNATTR_Ssp
+  | FNATTR_Sspreq
+  | FNATTR_Sspstrong
+  | FNATTR_Uwtable
+  | FNATTR_String of string
+  | FNATTR_Key_value of string * string
+  | FNATTR_Attr_grp of int
+and ident = ID_Global of string | ID_Local of string
+and typ =
+    TYPE_I of int
+  | TYPE_Pointer of typ
+  | TYPE_Void
+  | TYPE_Half
+  | TYPE_Float
+  | TYPE_Double
+  | TYPE_X86_fp80
+  | TYPE_Fp128
+  | TYPE_Ppc_fp128
+  | TYPE_Label
+  | TYPE_Metadata
+  | TYPE_X86_mmx
+  | TYPE_Array of (int * typ)
+  | TYPE_Function of (typ * typ list)
+  | TYPE_Struct of typ list
+  | TYPE_Packed_struct of typ list
+  | TYPE_Opaque
+  | TYPE_Vector of (int * typ)
+and metadata =
+    METADATA_Const of tvalue
+  | METADATA_Null
+  | METADATA_Id of string
+  | METADATA_String of string
+  | METADATA_Named of string list
+  | METADATA_Node of metadata list
+and icmp = Eq | Ne | Ugt | Uge | Ult | Ule | Sgt | Sge | Slt | Sle
+and fcmp =
+    False
+  | Oeq
+  | Ogt
+  | Oge
+  | Olt
+  | Ole
+  | One
+  | Ord
+  | Uno
+  | Ueq
+  | Ugt
+  | Uge
+  | Ult
+  | Ule
+  | Une
+  | True
+and ibinop =
+    Add of bool * bool
+  | Sub of bool * bool
+  | Mul of bool * bool
+  | Shl of bool * bool
+  | UDiv of bool
+  | SDiv of bool
+  | LShr of bool
+  | AShr of bool
+  | URem
+  | SRem
+  | And
+  | Or
+  | Xor
+and fbinop = FAdd | FSub | FMul | FDiv | FRem
+and fast_math = Nnan | Ninf | Nsz | Arcp | Fast
+and conversion_type =
+    Trunc
+  | Zext
+  | Sext
+  | Fptrunc
+  | Fpext
+  | Uitofp
+  | Sitofp
+  | Fptoui
+  | Fptosi
+  | Inttoptr
+  | Ptrtoint
+  | Bitcast
+and tvalue = typ * value
+and tident = typ * ident
+and value =
+    VALUE_Ident of ident
+  | VALUE_Integer of int
+  | VALUE_Float of float
+  | VALUE_Bool of bool
+  | VALUE_Null
+  | VALUE_Undef
+  | VALUE_Struct of tvalue list
+  | VALUE_Packed_struct of tvalue list
+  | VALUE_Array of tvalue list
+  | VALUE_Vector of tvalue list
+  | VALUE_Zero_initializer
+and instr =
+    INSTR_IBinop of ibinop * typ * value * value
+  | INSTR_ICmp of icmp * typ * value * value
+  | INSTR_FBinop of fbinop * fast_math list * typ * value * value
+  | INSTR_FCmp of fcmp * typ * value * value
+  | INSTR_Conversion of conversion_type * typ * value * typ
+  | INSTR_GetElementPtr of tvalue * tvalue list
+  | INSTR_ExtractElement of tvalue * tvalue
+  | INSTR_InsertElement of tvalue * tvalue * tvalue
+  | INSTR_ShuffleVector of tvalue * tvalue * tvalue
+  | INSTR_ExtractValue of tvalue * int list
+  | INSTR_InsertValue of tvalue * tvalue * int list
+  | INSTR_Call of tident * tvalue list
+  | INSTR_Alloca of typ * tvalue option * int option
+  | INSTR_Load of bool * tvalue * int option
+  | INSTR_Phi of typ * (value * ident) list
+  | INSTR_Select of tvalue * tvalue * tvalue
+  | INSTR_VAArg
+  | INSTR_LandingPad
+  | INSTR_Store of bool * tvalue * tident * int option
+  | INSTR_Fence
+  | INSTR_AtomicCmpXchg
+  | INSTR_AtomicRMW
+  | INSTR_Invoke of tident * tvalue list * tident * tident
+  | INSTR_Ret of tvalue
+  | INSTR_Ret_void
+  | INSTR_Br of tvalue * tident * tident
+  | INSTR_Br_1 of tident
+  | INSTR_Switch of tvalue * tident * (tvalue * tident) list
+  | INSTR_IndirectBr of tvalue * tident list
+  | INSTR_Resume of tvalue
+  | INSTR_Unreachable
+  | INSTR_Assign of ident * instr
+and toplevelentry =
+    TLE_Target of string
+  | TLE_Datalayout of string
+  | TLE_Declaration of declaration
+  | TLE_Definition of definition
+  | TLE_Type_decl of (ident * typ)
+  | TLE_Global of global
+  | TLE_Metadata of string * metadata
+  | TLE_Attribute_group of int * fn_attr list
+and toplevelentries = toplevelentry list
+and global = {
+  g_ident : ident;
+  g_typ : typ;
+  g_constant : bool;
+  g_value : value option;
+  g_linkage : linkage option;
+  g_visibility : visibility option;
+  g_dll_storage : dll_storage option;
+  g_thread_local : thread_local_storage option;
+  g_unnamed_addr : bool;
+  g_addrspace : int option;
+  g_externally_initialized : bool;
+  g_section : string option;
+  g_align : int option;
+}
+and thread_local_storage = TLS_Localdynamic | TLS_Initialexec | TLS_Localexec
+and declaration = {
+  dc_name : ident;
+  dc_type : typ;
+  dc_param_attrs : param_attr list * param_attr list list;
+}
+and definition = {
+  df_prototype : declaration;
+  df_args : ident list;
+  df_instrs : block list;
+  df_linkage : linkage option;
+  df_visibility : visibility option;
+  df_dll_storage : dll_storage option;
+  df_cconv : cconv option;
+  df_attrs : fn_attr list;
+  df_section : string option;
+  df_align : int option;
+  df_gc : string option;
+}
+and block = string * instr list
+and modul = {
+  m_name : string;
+  m_target : toplevelentry;
+  m_datalayout : toplevelentry;
+  m_globals : (string * global) list;
+  m_declarations : (string * declaration) list;
+  m_definitions : (string * definition) list;
+}

--- a/src/ollvm/ollvm_lexer.mli
+++ b/src/ollvm/ollvm_lexer.mli
@@ -1,0 +1,15 @@
+(*
+exception Lex_error_unterminated_string of Lexing.position
+val kw : string -> Ollvm_parser.token
+type ident_type = Named | NamedString | Unnamed
+val __ocaml_lex_tables : Lexing.lex_tables
+val token : Lexing.lexbuf -> Ollvm_parser.token
+val __ocaml_lex_token_rec : Lexing.lexbuf -> int -> Ollvm_parser.token
+val comment : Lexing.lexbuf -> Ollvm_parser.token
+val __ocaml_lex_comment_rec : Lexing.lexbuf -> int -> Ollvm_parser.token
+val string : Buffer.t -> Lexing.lexbuf -> string
+val __ocaml_lex_string_rec : Buffer.t -> Lexing.lexbuf -> int -> string
+val ident_body : Lexing.lexbuf -> string
+val __ocaml_lex_ident_body_rec : Lexing.lexbuf -> int -> string
+*)
+val parse : Lexing.lexbuf -> Ollvm_ast.toplevelentries

--- a/src/ollvm/ollvm_printer.ml
+++ b/src/ollvm/ollvm_printer.ml
@@ -1,4 +1,12 @@
 open Format
+
+(* Backward compatibility with 4.01.0 *)
+let rec pp_print_list ?(pp_sep = Format.pp_print_cut) pp_v ppf = function
+| [] -> ()
+| v :: vs ->
+    pp_v ppf v; if vs <> [] then (pp_sep ppf ();
+                                  pp_print_list ~pp_sep pp_v ppf vs)
+
 open Ollvm_ast
 
 type t = { local: int ref * (int, int) Hashtbl.t;

--- a/src/ollvm/ollvm_printer.mli
+++ b/src/ollvm/ollvm_printer.mli
@@ -1,0 +1,39 @@
+type t = {
+  local : int ref * (int, int) Hashtbl.t;
+  global : int ref * (int, int) Hashtbl.t;
+}
+val empty_env : unit -> t
+val find_env : int ref * (int, int) Hashtbl.t -> string -> int
+val find_local : t -> string -> int
+val find_global : t -> string -> int
+val reset_local : t -> t
+val pp_sep : string -> Format.formatter -> unit -> unit
+val pp_space : Format.formatter -> unit -> unit
+val pp_comma_space : Format.formatter -> unit -> unit
+val linkage : Format.formatter -> Ollvm_ast.linkage -> unit
+val dll_storage : Format.formatter -> Ollvm_ast.dll_storage -> unit
+val visibility : Format.formatter -> Ollvm_ast.visibility -> unit
+val cconv : Format.formatter -> Ollvm_ast.cconv -> unit
+val param_attr : Format.formatter -> Ollvm_ast.param_attr -> unit
+val fn_attr : Format.formatter -> Ollvm_ast.fn_attr -> unit
+val ident : t -> Format.formatter -> Ollvm_ast.ident -> unit
+val typ : Format.formatter -> Ollvm_ast.typ -> unit
+val icmp : Format.formatter -> Ollvm_ast.icmp -> unit
+val fcmp : Format.formatter -> Ollvm_ast.fcmp -> unit
+val ibinop : Format.formatter -> Ollvm_ast.ibinop -> unit
+val fbinop : Format.formatter -> Ollvm_ast.fbinop -> unit
+val fast_math : Format.formatter -> Ollvm_ast.fast_math -> unit
+val conversion_type : Format.formatter -> Ollvm_ast.conversion_type -> unit
+val instr : t -> Format.formatter -> Ollvm_ast.instr -> unit
+val value : t -> Format.formatter -> Ollvm_ast.value -> unit
+val tvalue : t -> Format.formatter -> Ollvm_ast.tvalue -> unit
+val tident : t -> Format.formatter -> Ollvm_ast.tident -> unit
+val toplevelentries :
+  t -> Format.formatter -> Ollvm_ast.toplevelentries -> unit
+val toplevelentry : t -> Format.formatter -> Ollvm_ast.toplevelentry -> unit
+val metadata : t -> Format.formatter -> Ollvm_ast.metadata -> unit
+val global : t -> Format.formatter -> Ollvm_ast.global -> unit
+val declaration : t -> Format.formatter -> Ollvm_ast.declaration -> unit
+val definition : t -> Format.formatter -> Ollvm_ast.definition -> unit
+val block : t -> Format.formatter -> Ollvm_ast.block -> unit
+val modul : t -> Format.formatter -> Ollvm_ast.modul -> unit

--- a/src/ollvm_llvmgateway/.depend
+++ b/src/ollvm_llvmgateway/.depend
@@ -1,0 +1,3 @@
+ollvm_llvmgateway.cmi :
+ollvm_llvmgateway.cmo : ollvm_llvmgateway.cmi
+ollvm_llvmgateway.cmx : ollvm_llvmgateway.cmi


### PR DESCRIPTION
- Some fixes
- Restore compatibility with 4.01: src/ollvm/ollvm.mli is generated by ./configure
