### PR TITLE
Fix the example in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let _ =
   (* variables declaration *)
   let (m, x0) =
     M.local m T.i1 "" in
-  let (m, [x1; x2; x3; arg]) =
+  let (m, [x1; x2; x3; x4]) =
     M.locals m T.i32 [""; ""; ""; ""] in
   let (m, [entry_b; then_b; else_b]) =
     M.locals m T.label ["entry"; "then"; "else" ] in


### PR DESCRIPTION
The example in the README defines the variable `arg` but uses `x4` instead.
This commit renames `arg` into `x4` so that the example is compiled without error.
