### PR TITLE
Allow LLVM 3.6 in the opam file

### DIFF
--- a/opam
+++ b/opam
@@ -18,5 +18,5 @@ remove: [
         ]
 depends: [ "ocamlfind" { build }
            "menhir" { build } ]
-conflicts: [ "llvm"  { != "3.5" } ]
+conflicts: [ "llvm"  { < "3.5" } ]
 depopts: [ "llvm" ]


### PR DESCRIPTION
I tested the example in the `README.md` and it seems to work.

Compilation of both `ollvm` and the example raise a ton of warnings but I think it's an orthogonal issue.
